### PR TITLE
bump version to 3.6.7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #   include dropbox
 class dropbox (
-  $version = '2.10.41',
+  $version = '3.6.7',
 ){
   package { 'Dropbox':
     ensure   => 'installed',


### PR DESCRIPTION
Ran locally, no issues on 10.10.

```
script/cibuild
$ script/cibuild
Using rake 10.3.2
Using CFPropertyList 2.2.8
Using addressable 2.3.6
Using ansi 1.4.3
Using json_pure 1.8.1
Using hiera 1.3.4
Using highline 1.6.21
Using json 1.8.1
Using thor 0.19.1
Using librarian 0.1.2
Using librarian-puppet 0.9.17
Using multipart-post 2.0.0
Using faraday 0.9.0
Using faraday_middleware 0.9.1
Using hashie 2.1.2
Using multi_json 1.10.1
Using netrc 0.7.7
Using octokit 1.25.0
Using facter 2.1.0
Using rgen 0.6.6
Using puppet 3.6.2
Using boxen 1.5.2
Using puppet-lint 0.3.2
Using metaclass 0.0.4
Using mocha 1.1.0
Using puppet-syntax 1.3.0
Using rspec-support 3.0.4
Using rspec-core 3.0.4
Using diff-lcs 1.2.5
Using rspec-expectations 3.0.4
Using rspec-mocks 3.0.4
Using rspec 3.0.0
Using rspec-puppet 0.1.6
Using puppetlabs_spec_helper 0.8.0
Using cardboard 1.0.4
Using bundler 1.10.3
Bundle complete! 1 Gemfile dependency, 36 gems now installed.
Bundled gems are installed into ./.bundle.
--> Checking syntax:
./manifests/init.pp: Syntax OK
./spec/classes/dropbox_spec.rb: Syntax OK
./spec/spec_helper.rb: Syntax OK
--> Running specs:
.

5 deprecation warnings total

Finished in 0.66133 seconds (files took 0.44836 seconds to load)
1 example, 0 failures
--> Checking lint:
```
